### PR TITLE
fix(ManualLabor): Fix BeforeDamagedEvent import

### DIFF
--- a/src/main/java/org/terasology/manualLabor/systems/BonusToolDamageSystem.java
+++ b/src/main/java/org/terasology/manualLabor/systems/BonusToolDamageSystem.java
@@ -20,7 +20,7 @@ import org.terasology.entitySystem.event.ReceiveEvent;
 import org.terasology.entitySystem.systems.BaseComponentSystem;
 import org.terasology.entitySystem.systems.RegisterMode;
 import org.terasology.entitySystem.systems.RegisterSystem;
-import org.terasology.logic.health.BeforeDamagedEvent;
+import org.terasology.logic.health.event.BeforeDamagedEvent;
 import org.terasology.manualLabor.components.BonusToolDamageComponent;
 import org.terasology.rendering.nui.layers.ingame.inventory.GetItemTooltip;
 import org.terasology.rendering.nui.widgets.TooltipLine;


### PR DESCRIPTION
- MovingBlock/Terasology#3677 extracts contents of engine/logic/health/ in new health module
- BeforeDamagedEvent class now resides in Health/logic/health/event/