### PR TITLE
feat: crafting a wooden cup no longer requires crafting lvl 1

### DIFF
--- a/assets/prefabs/items/assemblyProcesses/AssembleWoodenCup.prefab
+++ b/assets/prefabs/items/assemblyProcesses/AssembleWoodenCup.prefab
@@ -1,5 +1,5 @@
 {
-  "Parent": "AssemblingBaseProcessPart",
+  "Parent": "CrudeAssemblingBaseProcessPart",
   "ProcessDefinition": {
     "processType": "ManualLabor:CrudeAssembling"
   },


### PR DESCRIPTION
The player should not die of thirst just because they forget to click a button for training the "crafting" skill at least one level right after starting the game.

The skill requirement is added by https://github.com/Terasology/ManualLaborEventualSkills/blob/develop/deltas/ManualLabor/prefabs/AssemblingBaseProcessPart.prefab for all non-crude assembly processes, that's why we're changing the parent process here.