### PR TITLE
fix: particle effect in multiplayer

### DIFF
--- a/assets/prefabs/particleEffects/sheepShearingParticleEffect.prefab
+++ b/assets/prefabs/particleEffects/sheepShearingParticleEffect.prefab
@@ -49,5 +49,6 @@
         "lightRenderingDistance": 0.0,
         "lightAttenuationFalloff": 1.25,
         "lightDiffuseIntensity": 1.0
-    }
+    },
+    "network":{}
 }


### PR DESCRIPTION
### How to test

- Play Josharias Survival in multiplayer mode with the latest Manual Labor, with 2 players.
- Give yourself a crude shear using ```give crudeshears``` and spawn a sheep using ```spawnPrefab sheep```.
- Use shear on sheep and check if the particle effect is played for the second player 

